### PR TITLE
Support FreeBSD

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "author": "uiureo",
   "os": [
+    "freebsd",
     "darwin",
     "linux"
   ],


### PR DESCRIPTION
This Pull Request depends tj/node-cliparoo/pull/5 and uiureo/node-screencapture/pull/7.

My machine is FreeBSD 11.0-CURRENT, and this works perfectly for me.