### PR TITLE
Version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gyazo-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Gyazo for hackers",
   "main": "./lib/gyazo.js",
   "repository": {


### PR DESCRIPTION
I still can't install `gyazo-cli` on FreeBSD by `npm` command.

This Pull Request reflects uiureo/gyazo-cli/pull/4, so this will resolve above.