### PR TITLE
fix DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "optimist": "^0.6.1",
     "osenv": "0.0.3",
     "screencapture": "^0.3.0",
-    "tmp": "0.0.23"
+    "tmp": "0.1.0"
   },
   "devDependencies": {
     "tape": "^2.13.0",


### PR DESCRIPTION
Said DeprecationWarning when uploading files with gyazo.

$ gyazo test.png
(node: 80961) [DEP0022] DeprecationWarning: os.tmpDir () is deprecated. Use os.tmpdir () instead.

Updated tmp module because it was old.